### PR TITLE
Refactor scripts to use shared library for common functions

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,1 +1,2 @@
 disable=SC2317 # parallel and trap fool shellcheck
+disable=SC1091 # can't follow dynamically sourced library files (checked separately)

--- a/bmctest.sh
+++ b/bmctest.sh
@@ -8,6 +8,13 @@ set -eu
 # bmctest.sh tests the hosts from the supplied yaml config file
 # are working with the required ironic opperations (register, power, virtual media)
 
+# Source common library functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+# shellcheck source=lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+
 # this is used to skip the tests if we fail to start ironic
 SKIP_TESTS="false"
 COREOS_BUILDS="https://builds.coreos.fedoraproject.org/streams/stable.json"
@@ -54,21 +61,21 @@ if [[ -z ${INTERFACE:-} ]]; then
     exit 1
 fi
 
-if [[ ! -e ${CONFIGFILE:-} ]]; then
-    echo "ERROR: config file \"${CONFIGFILE:-}\" does not exist"
+if ! validate_file_exists "${CONFIGFILE:-}" "config file"; then
     usage
     exit 1
 fi
 
+timestamp "validating config structure"
+if ! validate_upstream_config "${CONFIGFILE}"; then
+    exit 1
+fi
+HOST_COUNT=$(count_hosts "${CONFIGFILE}" "upstream")
+timestamp "found $HOST_COUNT host(s) in config"
+
 if [[ -n $TLS_PORT ]]; then
     TLS_ENABLE="true"
 fi
-
-function timestamp {
-    echo -n "$(date +%T) "
-    echo "$1"
-}
-export -f timestamp
 
 ERROR_LOG=$(mktemp)
 export ERROR_LOG
@@ -82,18 +89,10 @@ function cleanup {
 trap "cleanup" EXIT
 
 timestamp "checking / installing dependencies (passwordless sudo, podman, curl, parallel, nc, yq)"
-if ! sudo true; then
-    echo "ERROR: passwordless sudo not available"
+if ! check_sudo; then
     exit 1
 fi
-for dep in curl nc podman jq yq parallel; do
-    if ! command -v $dep > /dev/null 2>&1; then
-        sudo dnf install -y curl nc jq podman python3-pip parallel
-        python3 -m pip install yq
-        echo "will cite" | parallel --citation > /dev/null 2>&1 || true
-        break
-    fi
-done
+ensure_dependencies
 
 timestamp "checking / getting ISO image"
 ISO_URL=$(curl -s "$COREOS_BUILDS" | jq -r '.architectures.x86_64.artifacts.metal.formats.iso.disk.location')
@@ -109,21 +108,18 @@ sudo podman rm -f -t 0 bmctest
 sudo podman rm -f -t 0 bmcicli
 
 timestamp "checking TCP 6385 port for Ironic is not already in use"
-if nc -z localhost 6385; then
-    echo "ERROR: Ironic port already in use, exiting"
+if ! check_port_available 6385 "Ironic"; then
     exit 1
 fi
 
 timestamp "checking TCP $HTTP_PORT port for http is not already in use"
-if nc -z localhost "$HTTP_PORT"; then
-    echo "ERROR: http port already in use, exiting"
+if ! check_port_available "$HTTP_PORT" "HTTP"; then
     exit 1
 fi
 
 if [[ "$TLS_ENABLE" == "true" ]]; then
     timestamp "checking TCP $TLS_PORT port for https is not already in use"
-    if nc -z localhost "$TLS_PORT"; then
-        echo "ERROR: https port already in use, exiting"
+    if ! check_port_available "$TLS_PORT" "HTTPS"; then
         exit 1
     fi
 fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# common.sh - Shared functions for bmctest
+# This library provides common utilities used by both bmctest.sh and ocpbmctest.sh
+
+export BMCTEST_VERSION="0.2.0"
+
+# Print timestamped messages
+function timestamp {
+    echo -n "$(date +%T) "
+    echo "$1"
+}
+
+# Check if passwordless sudo is available
+function check_sudo {
+    if ! sudo true; then
+        echo "ERROR: passwordless sudo not available"
+        return 1
+    fi
+}
+
+# Ensure all required dependencies are installed
+# Usage: ensure_dependencies
+function ensure_dependencies {
+    local deps=(curl nc podman jq yq parallel)
+    local missing=()
+
+    for dep in "${deps[@]}"; do
+        if ! command -v "$dep" > /dev/null 2>&1; then
+            missing+=("$dep")
+        fi
+    done
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        timestamp "installing missing dependencies: ${missing[*]}"
+        sudo dnf install -y curl jq podman python3-pip parallel nc
+        python3 -m pip install yq
+        echo "will cite" | parallel --citation > /dev/null 2>&1 || true
+    fi
+}
+
+# Validate that a file exists
+# Usage: validate_file_exists path/to/file "description"
+function validate_file_exists {
+    local file=$1
+    local description=${2:-"file"}
+    if [[ ! -e ${file:-} ]]; then
+        echo "ERROR: ${description} \"${file:-}\" does not exist"
+        return 1
+    fi
+    return 0
+}
+
+# Check if a TCP port is available (not in use)
+# Usage: check_port_available port service_name
+function check_port_available {
+    local port=$1
+    local service=$2
+    if nc -z localhost "$port" 2>/dev/null; then
+        echo "ERROR: ${service} port ${port} already in use"
+        return 1
+    fi
+    return 0
+}
+
+# Debug logging - only prints if BMCTEST_DEBUG is set
+# Usage: debug_log "message"
+function debug_log {
+    if [[ "${BMCTEST_DEBUG:-0}" == "1" ]]; then
+        echo "[DEBUG $(date +%T)] $*" >&2
+    fi
+}
+
+# Export functions for use in subshells (e.g., parallel)
+export -f timestamp
+export -f debug_log

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+
+# config.sh - Configuration parsing and validation functions for bmctest
+
+# Transform OpenShift install-config.yaml to upstream format
+# Usage: transform_ocp_to_upstream input.yaml output.yaml
+function transform_ocp_to_upstream {
+    local input=$1
+    local output=$2
+
+    debug_log "Transforming OpenShift config to upstream format"
+
+    yq -y '{hosts: [.platform.baremetal.hosts[] | {
+        name,
+        bmc: {
+            boot: (.bmc.address | capture("(?<boot>[^+:]+)")).boot,
+            protocol: (.bmc.address | if test("\\+(?<proto>[^:]+)") then (. | capture("\\+(?<proto>[^:]+)")).proto else "https" end),
+            address: (.bmc.address | capture("://(?<addr>[^/]+)")).addr,
+            systemid: (.bmc.address | capture("://(?<addr>[^/]+)(?<path>/.*$)")).path,
+            username: .bmc.username,
+            password: .bmc.password,
+            insecure: .bmc.disableCertificateVerification }
+        }]}' "$input" > "$output"
+
+    local result=$?
+    if [[ $result -ne 0 ]]; then
+        echo "ERROR: Failed to transform config"
+        return 1
+    fi
+
+    debug_log "Config transformation completed"
+    return 0
+}
+
+# Extract provisioning interface from OpenShift config
+# Usage: get_ocp_interface config.yaml
+function get_ocp_interface {
+    local config=$1
+    local interface
+
+    interface=$(yq -r '.platform.baremetal.provisioningBridge' "$config")
+    if [[ -z "$interface" || "$interface" = "null" ]]; then
+        echo "WARNING: no provisioningBridge in config, defaulting to externalBridge" >&2
+        interface=$(yq -r '.platform.baremetal.externalBridge' "$config")
+    fi
+
+    if [[ -z "$interface" || "$interface" = "null" ]]; then
+        echo "ERROR: No provisioning interface found in config" >&2
+        return 1
+    fi
+
+    echo "$interface"
+}
+
+# Count hosts in config
+# Usage: count_hosts config.yaml format
+# format: 'ocp' or 'upstream'
+function count_hosts {
+    local config=$1
+    local format=$2
+    local count
+
+    case $format in
+        ocp)
+            count=$(yq -r '.platform.baremetal.hosts | length' "$config" 2>/dev/null || echo "0")
+            ;;
+        upstream)
+            count=$(yq -r '.hosts | length' "$config" 2>/dev/null || echo "0")
+            ;;
+        *)
+            echo "0"
+            return 1
+            ;;
+    esac
+
+    echo "$count"
+}
+
+# Validate OpenShift install-config.yaml structure
+# Usage: validate_ocp_config path/to/install-config.yaml
+function validate_ocp_config {
+    local config=$1
+
+    debug_log "Validating OpenShift config structure"
+
+    # Check for required platform.baremetal section
+    if ! yq -e '.platform.baremetal' "$config" >/dev/null 2>&1; then
+        echo "ERROR: config missing platform.baremetal section"
+        return 1
+    fi
+
+    # Check for provisioning interface
+    local interface
+    interface=$(yq -r '.platform.baremetal.provisioningBridge // .platform.baremetal.externalBridge // empty' "$config")
+    if [[ -z "$interface" || "$interface" == "null" ]]; then
+        echo "ERROR: config missing provisioningBridge or externalBridge"
+        return 1
+    fi
+
+    # Check for hosts
+    local host_count
+    host_count=$(yq -r '.platform.baremetal.hosts | length' "$config" 2>/dev/null || echo "0")
+    if [[ "$host_count" -eq 0 ]]; then
+        echo "ERROR: config has no hosts defined"
+        return 1
+    fi
+
+    debug_log "OpenShift config validation passed: $host_count host(s) found"
+    return 0
+}
+
+# Validate upstream bmctest config.yaml structure
+# Usage: validate_upstream_config path/to/config.yaml
+function validate_upstream_config {
+    local config=$1
+
+    debug_log "Validating upstream config structure"
+
+    # Check for hosts section
+    if ! yq -e '.hosts' "$config" >/dev/null 2>&1; then
+        echo "ERROR: config missing hosts section"
+        return 1
+    fi
+
+    # Check for hosts
+    local host_count
+    host_count=$(yq -r '.hosts | length' "$config" 2>/dev/null || echo "0")
+    if [[ "$host_count" -eq 0 ]]; then
+        echo "ERROR: config has no hosts defined"
+        return 1
+    fi
+
+    # Validate each host has required BMC fields
+    local invalid_hosts
+    invalid_hosts=$(yq -r '.hosts[] | select(.bmc.address == null or .bmc.username == null) | .name // "unnamed"' "$config" 2>/dev/null)
+    if [[ -n "$invalid_hosts" ]]; then
+        echo "ERROR: hosts missing required BMC fields: $invalid_hosts"
+        return 1
+    fi
+
+    debug_log "Upstream config validation passed: $host_count host(s) found"
+    return 0
+}
+

--- a/ocpbmctest.sh
+++ b/ocpbmctest.sh
@@ -5,6 +5,13 @@ set -eu
 # intermediate script to parse install-config.yaml,
 # create the ironic image from openshift release and then call bmctest.sh
 
+# Source common library functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "${SCRIPT_DIR}/lib/common.sh"
+# shellcheck source=lib/config.sh
+source "${SCRIPT_DIR}/lib/config.sh"
+
 # defaults
 RELEASE="4.18"
 PULL_SECRET="/opt/dev-scripts/pull_secret.json"
@@ -38,35 +45,21 @@ while getopts "r:p:T:s:t:c:l:h" opt; do
     esac
 done
 
-if [[ ! -e ${CONFIGFILE:-} ]]; then
-    echo "ERROR: config file \"${CONFIGFILE:-}\" does not exist"
+if ! validate_file_exists "${CONFIGFILE:-}" "config file"; then
     usage
     exit 1
 fi
 
-if [[ ! -e ${PULL_SECRET:-} ]]; then
-    echo "ERROR: pull secret file \"${PULL_SECRET:-}\" does not exist"
+if ! validate_file_exists "${PULL_SECRET:-}" "pull secret file"; then
     usage
     exit 1
 fi
-
-function timestamp {
-    echo -n "$(date +%T) "
-    echo "$1"
-}
 
 timestamp "checking/installing dependencies (passwordless sudo, yq, curl, podman)"
-if ! sudo true; then
-    echo "ERROR: passwordless sudo not available"
+if ! check_sudo; then
     exit 1
 fi
-for dep in curl jq yq podman; do
-    if ! command -v $dep > /dev/null 2>&1; then
-        sudo dnf install -y curl jq podman python3-pip
-        python3 -m pip install yq
-        break
-    fi
-done
+ensure_dependencies
 
 timestamp "getting the release image url"
 # shellcheck disable=SC2001
@@ -89,25 +82,33 @@ function cleanup {
 }
 trap "cleanup" EXIT
 
-timestamp "extracting the provisioning interface from $CONFIGFILE"
-INTERFACE=$(yq -r '.platform.baremetal.provisioningBridge' "$CONFIGFILE")
-if [[ -z "$INTERFACE" || $INTERFACE = "null" ]]; then
-    timestamp "WARNING: found no provision interface in config, defaulting to 'externalBridge'"
-    INTERFACE=$(yq -r '.platform.baremetal.externalBridge' "$CONFIGFILE")
+timestamp "validating OpenShift config structure"
+if ! validate_ocp_config "$CONFIGFILE"; then
+    exit 1
 fi
 
-timestamp "extracting the hosts from $CONFIGFILE"
-yq -y '{hosts: [.platform.baremetal.hosts[] | {
-        name,
-        bmc: {
-            boot: (.bmc.address | capture("(?<boot>[^+:]+)")).boot,
-            protocol: (.bmc.address | if test("\\+(?<proto>[^:]+)") then (. | capture("\\+(?<proto>[^:]+)")).proto else "https" end),
-            address: (.bmc.address | capture("://(?<addr>[^/]+)")).addr,
-            systemid: (.bmc.address | capture("://(?<addr>[^/]+)(?<path>/.*$)")).path,
-            username: .bmc.username,
-            password: .bmc.password,
-            insecure: .bmc.disableCertificateVerification }
-        }]}' "$CONFIGFILE" > "$INPUTFILE"
+timestamp "extracting the provisioning interface from $CONFIGFILE"
+if ! INTERFACE=$(get_ocp_interface "$CONFIGFILE"); then
+    exit 1
+fi
+HOST_COUNT=$(count_hosts "$CONFIGFILE" "ocp")
+timestamp "found $HOST_COUNT host(s) in config, using interface: $INTERFACE"
+
+timestamp "transforming config to upstream format"
+if ! transform_ocp_to_upstream "$CONFIGFILE" "$INPUTFILE"; then
+    exit 1
+fi
+
+if [[ "${BMCTEST_DEBUG:-0}" == "1" ]]; then
+    debug_log "Transformed config:"
+    cat "$INPUTFILE" >&2
+fi
+
+timestamp "validating transformed config"
+if ! validate_upstream_config "$INPUTFILE"; then
+    echo "ERROR: Config transformation failed validation"
+    exit 1
+fi
 
 timestamp "calling bmctest.sh"
 "$(dirname "$0")"/bmctest.sh -i "$IRONICIMAGE" -I "$INTERFACE" -p "$HTTP_PORT" -T "$TLS_PORT" -t "$TIMEOUT" -s "$PULL_SECRET" -l "$LOG_SAVE" -c "$INPUTFILE"


### PR DESCRIPTION
Extract duplicated code from bmctest.sh and ocpbmctest.sh into
lib/common.sh (logging, sudo, dependencies, file/port validation)
and lib/config.sh (config parsing, transformation, validation).

Assisted-By: Claude 4.6 Opush High