### PR TITLE
Fix unset IRONIC_VERSION crash when Ironic fails to start

### DIFF
--- a/bmctest.sh
+++ b/bmctest.sh
@@ -405,7 +405,7 @@ echo; echo "========== Found $EXIT errors =========="
 cat "$ERROR_LOG"
 echo
 echo "========== Version Information =========="
-echo "Ironic Version: $IRONIC_VERSION"
+echo "Ironic Version: ${IRONIC_VERSION:-unknown}"
 echo "Ironic Image: $IRONICIMAGE"
 echo
 logf="ironic_$(date +%Y-%m-%d_%H-%M).log"


### PR DESCRIPTION
Under set -u, referencing IRONIC_VERSION in the summary output would cause an error if the API never became available. Default to "unknown".