### PR TITLE
execute ensure dependencies earlier

### DIFF
--- a/bmctest.sh
+++ b/bmctest.sh
@@ -66,6 +66,12 @@ if ! validate_file_exists "${CONFIGFILE:-}" "config file"; then
     exit 1
 fi
 
+timestamp "checking / installing dependencies (passwordless sudo, podman, curl, parallel, nc, yq)"
+if ! check_sudo; then
+    exit 1
+fi
+ensure_dependencies
+
 timestamp "validating config structure"
 if ! validate_upstream_config "${CONFIGFILE}"; then
     exit 1
@@ -88,11 +94,6 @@ function cleanup {
 }
 trap "cleanup" EXIT
 
-timestamp "checking / installing dependencies (passwordless sudo, podman, curl, parallel, nc, yq)"
-if ! check_sudo; then
-    exit 1
-fi
-ensure_dependencies
 
 timestamp "checking / getting ISO image"
 ISO_URL=$(curl -s "$COREOS_BUILDS" | jq -r '.architectures.x86_64.artifacts.metal.formats.iso.disk.location')


### PR DESCRIPTION
validate_upstream_config and count_hosts already use yq as dependency. If they are missing the script fails with strange errors. So move the dependency check at the start.

Without this it would fail with a hosts error for me
```
./bmctest.sh -I enp6s18 -c config.yaml 
13:39:30 validating config structure
ERROR: config missing hosts section
```

While the config included hosts
```
cat config.yaml 
hosts:
    - name: some-server
      bmc:
          boot: redfish-virtualmedia
          protocol: https
          address: 10.4.82.100
          systemid: /redfish/v1/Systems/systems
          username: ironic
          password: <..>
          insecure: true
```